### PR TITLE
ユーザ登録時の項目追加とユーザ情報編集機能の実装（バックエンド）

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,12 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :phone_number])
+    # devise_parameter_sanitizer.permit(:sign_in, keys: [:username])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :phone_number])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,13 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  VALID_PHONE_REGEX = /\A0\d{9,10}\z/
+
+  validates :name, allow_blank: true, length: { maximum: 20 }
+  validates :phone_number,
+            format: { with: VALID_PHONE_REGEX },
+            length: { in: 10..11 },
+            allow_blank: true,
+            uniqueness: true
 end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -6,6 +6,14 @@
     = f.label :email
     %br/
     = f.email_field :email, autofocus: true, autocomplete: "email"
+  .field
+    = f.label :name
+    %br/
+    = f.text_field :name, autocomplete: "name"
+  .field
+    = f.label :phone_number
+    %br/
+    = f.text_field :phone_number, autocomplete: "phone_number"
   - if devise_mapping.confirmable? && resource.pending_reconfirmation?
     %div
       Currently waiting confirmation for: #{resource.unconfirmed_email}

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -6,6 +6,14 @@
     %br/
     = f.email_field :email, autofocus: true, autocomplete: "email"
   .field
+    = f.label :name
+    %br/
+    = f.text_field :name, autocomplete: "name"
+  .field
+    = f.label :phone_number
+    %br/
+    = f.text_field :phone_number, autocomplete: "phone_number"
+  .field
     = f.label :password
     - if @minimum_password_length
       %em

--- a/app/views/restaurants/index.html.haml
+++ b/app/views/restaurants/index.html.haml
@@ -110,6 +110,7 @@
 -# 以下の部分はログイン確認用の仮実装
 .user_test
   - if user_signed_in?
+    = link_to 'edit',   edit_user_registration_path
     = link_to 'logout', destroy_user_session_path, method: :delete
   - else
     = link_to 'sign up', new_user_registration_path


### PR DESCRIPTION
# What
- ユーザ登録時に以下の項目を入力可能に（それぞれにバリデーションも設定）
  - name
  - phone_number
- ユーザ情報の編集機能を実装（ログイン時）

# Why
- ユーザ情報を細かく編集可能な状態にするため